### PR TITLE
SD-1400 fsnotify leaks file descriptors on Close()

### DIFF
--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -208,6 +208,7 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 		n     int                                     // Number of bytes read with read()
 		errno error                                   // Syscall errno
 	)
+
 	for {
 		var buf [syscall.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
 		n, errno = syscall.Read(w.fd, buf[:])
@@ -241,7 +242,6 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 // readEvents reads from the inotify file descriptor, converts the
 // received events into Event objects and sends them via the Event channel
 func (w *Watcher) readEvents() {
-	
 	eventChan := make(chan bufAndLen)
 	errChan := make(chan error)
 
@@ -252,7 +252,7 @@ func (w *Watcher) readEvents() {
 	   the error and internal event queues */
 	for {
 		select {
-		case <-w.done:	
+		case <-w.done:
 			w.shutdownAndDrainReader(eventChan, errChan)
 			return
 		case buf, ok := <- eventChan:
@@ -328,6 +328,7 @@ func (w *Watcher) handleEvent(buf []byte, n int) bool {
 				}
 			}
 			w.fsnmut.Unlock()
+
 			select {
 			case <-w.done:
 				return false

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -210,8 +210,10 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 	)
 
 	for {
+
 		var buf [syscall.SizeofInotifyEvent * 4096]byte // Buffer for a maximum of 4096 raw events
 		n, errno = syscall.Read(w.fd, buf[:])
+
 		// If EOF is received
 		if n == 0 {
 			close(dataChan)
@@ -225,7 +227,6 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 			close(errChan)
 			return
 		}
-
 		if n < -1 {
 			errChan <- os.NewSyscallError("read", errno)
 			continue
@@ -246,7 +247,6 @@ func (w *Watcher) readEvents() {
 	errChan := make(chan error)
 
 	go w.asyncSyscallRead(eventChan, errChan)
-
 	/* Listen for syscall reads or shutdown signals.
 	   If we're shutting down, don't block trying to serve
 	   the error and internal event queues */
@@ -260,6 +260,7 @@ func (w *Watcher) readEvents() {
 				w.shutdownAndDrainReader(eventChan, errChan)
 				return
 			}
+
 			// `handleEvent` returns false if not all 
 			// messages could be sent before shutdown
 			if !w.handleEvent(buf.buf, buf.len) {

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -240,6 +240,9 @@ func (w *Watcher) readEvents() {
 
 	go w.asyncSyscallRead(eventChan, errChan)
 
+ 	/* Listen for syscall reads or shutdown signals.
+	   If we're shutting down, don't block trying to serve
+	   the error and internal event queues */
 	for {
 		select {
 		case <-w.done:

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -330,7 +330,7 @@ func (w *Watcher) handleEvent(buf []byte, n int) bool {
 			w.fsnmut.Unlock()
 			select {
 			case <-w.done:
-	                        return false
+				return false
 			case w.internalEvent <- event:
 			}
 		}

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -218,7 +218,14 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 			return
 		}
 
-		if n < 0 {
+		// If the FD has been closed we get -1
+                if n == -1 {
+                        close(dataChan)
+                        close(errChan)
+                        return
+                }
+
+		if n < -1 {
 			errChan <- os.NewSyscallError("read", errno)
 			continue
 		}

--- a/fsnotify_linux.go
+++ b/fsnotify_linux.go
@@ -197,8 +197,8 @@ func (w *Watcher) removeWatch(path string) error {
 }
 
 type bufAndLen struct {
-  buf []byte
-  len int
+	buf []byte
+	len int
 }
 
 // Block on `syscall.Read` and return any errors or new messages on a channel
@@ -219,11 +219,11 @@ func (w *Watcher) asyncSyscallRead(dataChan chan bufAndLen, errChan chan error) 
 		}
 
 		// If the FD has been closed we get -1
-                if n == -1 {
-                        close(dataChan)
-                        close(errChan)
-                        return
-                }
+		if n == -1 {
+			close(dataChan)
+			close(errChan)
+			return
+		}
 
 		if n < -1 {
 			errChan <- os.NewSyscallError("read", errno)
@@ -247,7 +247,7 @@ func (w *Watcher) readEvents() {
 
 	go w.asyncSyscallRead(eventChan, errChan)
 
- 	/* Listen for syscall reads or shutdown signals.
+	/* Listen for syscall reads or shutdown signals.
 	   If we're shutting down, don't block trying to serve
 	   the error and internal event queues */
 	for {


### PR DESCRIPTION
We've observed that fsnotify's Close() call returns immediately, but it often ends up blocked, waiting for an inotify read before closing. We should free all resources immediately, and discard events that might happen after Close() is called.